### PR TITLE
Make build process repeatable. Fixes #7

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href='css/railscasts.css' rel='stylesheet' />
   </head>
   <body>
-    <div id='app'>APP</div>
+    <!--START--><div id='app'></div><!--STOP-->
     <script src='bundle.js'></script>
   </body>
 </html>

--- a/src/render.js
+++ b/src/render.js
@@ -14,7 +14,14 @@ var template = fs.readFileSync('./index.html', 'utf8');
 
 var target = process.argv[2];
 
+var startDiv = `<div id='app'>`;
+var stopDiv = '</div>';
+var startMarker = '<!--START-->' + startDiv;
+var stopMarker = stopDiv + '<!--STOP-->';
+var startIdx = template.indexOf(startMarker) + startMarker.length;
+var stopIdx = template.indexOf(stopMarker);
+
 fs.writeFileSync(target,
-  template.replace('APP',
-  ReactDOMServer.renderToString(
-    <App ast={ast} content={content} />)));
+  template.substring(0, startIdx) +
+  ReactDOMServer.renderToString(<App ast={ast} content={content} />) +
+  template.substring(stopIdx));


### PR DESCRIPTION
Previously when you ran `npm run build`, it would change index.html
in a way that prevented you from running `npm run build` again.
This change makes the builder more sophisticated, ensuring that
START and STOP markers stay in the index.html file, letting you
re-run the command.